### PR TITLE
User defined Unit

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT) [![codecov](https://codecov.io/gh/Loque-/guttr/branch/master/graph/badge.svg)](https://codecov.io/gh/Loque-/guttr)
 
-Utility for UI developers using OOCSS to return consistent gutters without having to use a grid system.
+Utility for UI developers using OOCSS to return consistent gutters without having to use a grid system. Allows user to configure gutter, unit and then individual breakpoints.
 
 
 ## Install
@@ -22,7 +22,8 @@ import { guttr } from 'guttr';
 
 const siteGutter = guttr({
     base: {
-        gutter: 16
+        gutter: 16,
+        unit: 'px',
     },
     breakpoints: {
         small: {
@@ -52,11 +53,11 @@ import siteGutter from 'path/to/config';
 // Returns standard gutter from config
 siteGutter()
 
-// Override percentage of gutter being used for all breakpoints
-siteGutter({ top: 1})
+// Returns gutter with an override for the top gutter used on all breakpoints
+siteGutter({ top: 1 })
 
-// Override percentage of gutter being used for a breakpoint (defined in the configuration) until reset
-siteGutter({}, { small: { top: 1 }, large: { top: 0.5 } })
+// Returns gutter with an override for different breakpoints defined in the example config above
+siteGutter({}, { small: { top: 1 }, large: { top: 0.5, right: 1, left: 1 } })
 
 ```
 
@@ -66,6 +67,3 @@ Grid systems are great but the fundemental quality is the gutters, this function
 
 I originally created this functionality in a mixin for SCSS before moving full time to ReactJS, I immediately re-created it in JS and have used it on every project since.
 
-## Improvements
-
-- Guttr only returns `px` values currently and should really return a configured metric

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "guttr",
-  "version": "1.0.8",
+  "version": "1.1.0",
   "description": "OOCSS padding with breakpoints",
   "main": "dist/index.js",
   "scripts": {

--- a/src/test.js
+++ b/src/test.js
@@ -2,7 +2,8 @@ import { guttr, generateGutter, buildPadding } from '.';
 
 const testConfig = {
     base: {
-        gutter: 16
+        gutter: 16,
+        unit: 'px',
         // It's unlikely the user will want to specify custom base multipliers
         // There is a test below for this instance
         // multipliers: { top: 0.5, right: 0.5, bottom: 0.5, left: 0.5 }
@@ -10,22 +11,22 @@ const testConfig = {
     breakpoints: {
         small: {
             gutter: 16,
-            mediaQuery: `@media(min-width: 768px)`
+            mediaQuery: `@media(min-width: 768px)`,
         },
         medium: {
             gutter: 16,
-            mediaQuery: `@media(min-width: 992px)`
+            mediaQuery: `@media(min-width: 992px)`,
         },
         large: {
             gutter: 28,
-            mediaQuery: `@media(min-width: 1300px)`
-        }
-    }
+            mediaQuery: `@media(min-width: 1300px)`,
+        },
+    },
 };
 
 const expectedGutterFromTestConfig = {
     padding: '8px 8px 8px 8px',
-    '@media(min-width: 1300px)': { padding: '14px 14px 14px 14px' }
+    '@media(min-width: 1300px)': { padding: '14px 14px 14px 14px' },
 };
 
 describe('BuildPadding', () => {
@@ -42,11 +43,11 @@ describe('BuildPadding', () => {
     });
 
     test('Accepts object with values for top, right, bottom and left for the second argument', () => {
-        const generatedPadding = buildPadding(10, {
+        const generatedPadding = buildPadding(10, 'px', {
             top: 0.25,
             right: 1,
             bottom: 0.25,
-            left: 1
+            left: 1,
         });
         const expectedPadding = '2.5px 10px 2.5px 10px';
         expect(generatedPadding).toStrictEqual(expectedPadding);
@@ -57,7 +58,7 @@ describe('GenerateGutter', () => {
     test('Returns default padding with no config', () => {
         const generatedGutter = generateGutter();
         const expectedGutter = {
-            padding: '8px 8px 8px 8px'
+            padding: '8px 8px 8px 8px',
         };
         expect(generatedGutter).toStrictEqual(expectedGutter);
     });
@@ -68,7 +69,7 @@ describe('Guttr', () => {
         const siteGutter = guttr();
         const generatedGutter = siteGutter();
         const expectedGutter = {
-            padding: '8px 8px 8px 8px'
+            padding: '8px 8px 8px 8px',
         };
         expect(generatedGutter).toStrictEqual(expectedGutter);
     });
@@ -77,7 +78,7 @@ describe('Guttr', () => {
         const siteGutter = guttr();
         const generatedGutter = siteGutter({ top: 1 });
         const expectedGutter = {
-            padding: '16px 8px 8px 8px'
+            padding: '16px 8px 8px 8px',
         };
         expect(generatedGutter).toStrictEqual(expectedGutter);
     });
@@ -86,7 +87,7 @@ describe('Guttr', () => {
         const siteGutter = guttr();
         const generatedGutter = siteGutter({ top: 1, right: 0.25 });
         const expectedGutter = {
-            padding: '16px 4px 8px 8px'
+            padding: '16px 4px 8px 8px',
         };
         expect(generatedGutter).toStrictEqual(expectedGutter);
     });
@@ -102,7 +103,7 @@ describe('Guttr', () => {
         const expectedGutter = {
             padding: '8px 8px 8px 8px',
             '@media(min-width: 768px)': { padding: '8px 8px 8px 16px' },
-            '@media(min-width: 1300px)': { padding: '14px 14px 14px 28px' }
+            '@media(min-width: 1300px)': { padding: '14px 14px 14px 28px' },
         };
 
         expect(generatedGutter).toStrictEqual(expectedGutter);
@@ -118,7 +119,7 @@ describe('Guttr', () => {
             padding: '8px 8px 8px 8px',
             '@media(min-width: 768px)': { padding: '8px 8px 8px 16px' },
             '@media(min-width: 992px)': { padding: '16px 8px 8px 16px' },
-            '@media(min-width: 1300px)': { padding: '28px 14px 14px 28px' }
+            '@media(min-width: 1300px)': { padding: '28px 14px 14px 28px' },
         };
 
         expect(generatedGutter).toStrictEqual(expectedGutter);
@@ -134,7 +135,7 @@ describe('Guttr', () => {
             padding: '8px 8px 0px 8px',
             '@media(min-width: 768px)': { padding: '8px 8px 0px 16px' },
             '@media(min-width: 992px)': { padding: '16px 8px 0px 16px' },
-            '@media(min-width: 1300px)': { padding: '28px 14px 0px 28px' }
+            '@media(min-width: 1300px)': { padding: '28px 14px 0px 28px' },
         };
 
         expect(generatedGutter).toStrictEqual(expectedGutter);
@@ -144,13 +145,13 @@ describe('Guttr', () => {
         const siteGutter = guttr({
             ...testConfig,
             base: {
-                multipliers: { top: 0.25, right: 0.5, bottom: 1, left: 0.5 }
-            }
+                multipliers: { top: 0.25, right: 0.5, bottom: 1, left: 0.5 },
+            },
         });
         const generatedGutter = siteGutter();
         const expectedGutter = {
             padding: '4px 8px 16px 8px',
-            '@media(min-width: 1300px)': { padding: '7px 14px 28px 14px' }
+            '@media(min-width: 1300px)': { padding: '7px 14px 28px 14px' },
         };
         expect(generatedGutter).toStrictEqual(expectedGutter);
     });
@@ -161,22 +162,63 @@ describe('Guttr', () => {
             breakpoints: {
                 small: {
                     gutter: 20,
-                    mediaQuery: `@media(min-width: 768px)`
+                    mediaQuery: `@media(min-width: 768px)`,
                 },
                 medium: {
-                    mediaQuery: `@media(min-width: 992px)`
+                    mediaQuery: `@media(min-width: 992px)`,
                 },
                 large: {
                     gutter: 28,
-                    mediaQuery: `@media(min-width: 1300px)`
-                }
-            }
+                    mediaQuery: `@media(min-width: 1300px)`,
+                },
+            },
         });
         const generatedGutter = siteGutter();
         const expectedGutter = {
             padding: '8px 8px 8px 8px',
             '@media(min-width: 768px)': { padding: '10px 10px 10px 10px' },
-            '@media(min-width: 1300px)': { padding: '14px 14px 14px 14px' }
+            '@media(min-width: 1300px)': { padding: '14px 14px 14px 14px' },
+        };
+        expect(generatedGutter).toStrictEqual(expectedGutter);
+    });
+
+    test('Change unit type in config', () => {
+        const siteGutter = guttr({
+            base: {
+                gutter: 1,
+                unit: 'rem',
+            },
+        });
+        const generatedGutter = siteGutter();
+        const expectedGutter = {
+            padding: '0.5rem 0.5rem 0.5rem 0.5rem',
+        };
+        expect(generatedGutter).toStrictEqual(expectedGutter);
+    });
+
+    test('Allow different units at different breakpoints', () => {
+        const siteGutter = guttr({
+            base: {
+                gutter: 1,
+                unit: 'rem',
+            },
+            breakpoints: {
+                small: {
+                    gutter: 16,
+                    unit: 'px',
+                    mediaQuery: `@media(min-width: 768px)`,
+                },
+                medium: {
+                    gutter: 4,
+                    mediaQuery: `@media(min-width: 992px)`,
+                },
+            },
+        });
+        const generatedGutter = siteGutter();
+        const expectedGutter = {
+            padding: '0.5rem 0.5rem 0.5rem 0.5rem',
+            '@media(min-width: 768px)': { padding: '8px 8px 8px 8px' },
+            '@media(min-width: 992px)': { padding: '2rem 2rem 2rem 2rem' },
         };
         expect(generatedGutter).toStrictEqual(expectedGutter);
     });


### PR DESCRIPTION
Also has an unfortunate trailing comma update.

You can now specify the unit that Guttr will use when producing padding;

```
const siteGutter = guttr({
    base: {
        gutter: 1,
        unit: 'rem',
    },
    breakpoints: {
        small: {
            gutter: 16,
            unit: 'px',
            mediaQuery: `@media(min-width: 768px)`,
        },
        medium: {
            gutter: 4,
            // will return to base if not specified
            mediaQuery: `@media(min-width: 992px)`,
        },
    },
});
```
